### PR TITLE
Added some code to let you write 'surface shaders' again. Sort of...

### DIFF
--- a/Assets/ShaderLibrary.meta
+++ b/Assets/ShaderLibrary.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3bf83b5ab2dc6764097b37726d962925
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ShaderLibrary/SurfaceShader.hlsl
+++ b/Assets/ShaderLibrary/SurfaceShader.hlsl
@@ -1,0 +1,80 @@
+#ifndef UNIVERSAL_SURFACE_SHADER_INCLUDED
+#define UNIVERSAL_SURFACE_SHADER_INCLUDED
+
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+
+// -------------------------------------
+// Surface shader defines
+#define SURFACE_SHADER
+
+// NOTE: This is duplicated from LitForwardPass, but we need this to be defined before the Varyings 
+// because it determines which fields are defined inside the Varyings. 
+#if defined(_PARALLAXMAP)
+#define REQUIRES_TANGENT_SPACE_VIEW_DIR_INTERPOLATOR
+#endif
+
+#if (defined(_NORMALMAP) || (defined(_PARALLAXMAP) && !defined(REQUIRES_TANGENT_SPACE_VIEW_DIR_INTERPOLATOR))) || defined(_DETAIL)
+#define REQUIRES_WORLD_SPACE_TANGENT_INTERPOLATOR
+#endif
+
+// -------------------------------------
+// Define the Varyings once, in one central place, to be re-used for both forward and deferred passes
+struct Varyings
+{
+    float2 uv                       : TEXCOORD0;
+
+#if defined(REQUIRES_WORLD_SPACE_POS_INTERPOLATOR)
+    float3 positionWS               : TEXCOORD1;
+#endif
+
+    half3 normalWS                  : TEXCOORD2;
+#if defined(REQUIRES_WORLD_SPACE_TANGENT_INTERPOLATOR)
+    half4 tangentWS                 : TEXCOORD3;    // xyz: tangent, w: sign
+#endif
+
+// How it's defined in LitForwardPass
+//#ifdef _ADDITIONAL_LIGHTS_VERTEX
+    //half4 fogFactorAndVertexLight   : TEXCOORD5; // x: fogFactor, yzw: vertex light
+//#else
+    //half  fogFactor                 : TEXCOORD5;
+//#endif
+
+// How it's defined in LitGbufferPass
+//#ifdef _ADDITIONAL_LIGHTS_VERTEX
+    //half3 vertexLighting            : TEXCOORD4;    // xyz: vertex lighting
+//#endif
+
+// This is me trying to consolidate them. This will presumably cause errors if _ADDITIONAL_LIGHTS_VERTEX is ever on ;_;
+#ifdef _ADDITIONAL_LIGHTS_VERTEX
+    half4 fogFactorAndVertexLight   : TEXCOORD4; // x: fogFactor, yzw: vertex light
+#else
+    half  fogFactor                 : TEXCOORD4;
+#endif
+
+#if defined(REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR)
+    float4 shadowCoord              : TEXCOORD5;
+#endif
+
+#if defined(REQUIRES_TANGENT_SPACE_VIEW_DIR_INTERPOLATOR)
+    half3 viewDirTS                 : TEXCOORD6;
+#endif
+
+    DECLARE_LIGHTMAP_OR_SH(staticLightmapUV, vertexSH, 7);
+#ifdef DYNAMICLIGHTMAP_ON
+    float2  dynamicLightmapUV       : TEXCOORD8; // Dynamic lightmap UVs
+#endif
+
+#ifdef USE_APV_PROBE_OCCLUSION
+    float4 probeOcclusion           : TEXCOORD9;
+#endif
+
+    float4 positionCS               : SV_POSITION;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+    UNITY_VERTEX_OUTPUT_STEREO
+};
+
+// -------------------------------------
+// CUSTOM: Forward declaration of SurfaceFunction. This function must be implemented in the shader
+void SurfaceFunction(Varyings IN, inout SurfaceData surfaceData);
+
+#endif // UNIVERSAL_SURFACE_SHADER_INCLUDED

--- a/Assets/ShaderLibrary/SurfaceShader.hlsl.meta
+++ b/Assets/ShaderLibrary/SurfaceShader.hlsl.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b97d47b497240e34c887037d141948b8
+timeCreated: 1615473362

--- a/Packages/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
+++ b/Packages/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
@@ -27,6 +27,7 @@ struct Attributes
     UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
+#if !defined(SURFACE_SHADER) // CUSTOM: SURFACESHADERS: We want to declare this in one central place: SurfaceShader.hlsl.
 struct Varyings
 {
     float2 uv                       : TEXCOORD0;
@@ -67,6 +68,7 @@ struct Varyings
     UNITY_VERTEX_INPUT_INSTANCE_ID
     UNITY_VERTEX_OUTPUT_STEREO
 };
+#endif // !defined(SURFACE_SHADER) // CUSTOM: SURFACESHADERS: We want to declare this in one central place: SurfaceShader.hlsl.
 
 void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData)
 {
@@ -239,7 +241,14 @@ void LitPassFragment(
 #endif
 
     SurfaceData surfaceData;
+    // CUSTOM: SURFACESHADERS: For surface shaders, just initialize the surface data with defaults and then call the surface function
+#if defined(SURFACE_SHADER)
+    surfaceData = (SurfaceData)0;
+    InitializeSurfaceDataForSurfaceShader(input.uv, surfaceData);
+    SurfaceFunction(input, surfaceData);
+#else
     InitializeStandardLitSurfaceData(input.uv, surfaceData);
+#endif // defined(SURFACE_SHADER)
 
 #ifdef LOD_FADE_CROSSFADE
     LODFadeCrossFade(input.positionCS);

--- a/Packages/com.unity.render-pipelines.universal/Shaders/LitGBufferPass.hlsl
+++ b/Packages/com.unity.render-pipelines.universal/Shaders/LitGBufferPass.hlsl
@@ -32,6 +32,7 @@ struct Attributes
     UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
+#if !defined(SURFACE_SHADER) // CUSTOM: SURFACESHADERS: We want to declare this in one central place: SurfaceShader.hlsl.
 struct Varyings
 {
     float2 uv                       : TEXCOORD0;
@@ -69,6 +70,7 @@ struct Varyings
     UNITY_VERTEX_INPUT_INSTANCE_ID
     UNITY_VERTEX_OUTPUT_STEREO
 };
+#endif // !defined(SURFACE_SHADER) // CUSTOM: SURFACESHADERS: We want to declare this in one central place: SurfaceShader.hlsl.
 
 void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData)
 {
@@ -210,7 +212,14 @@ FragmentOutput LitGBufferPassFragment(Varyings input)
 #endif
 
     SurfaceData surfaceData;
+    // CUSTOM: SURFACESHADERS: For surface shaders, just initialize the surface data with defaults and then call the surface function
+#if defined(SURFACE_SHADER)
+    surfaceData = (SurfaceData)0;
+    InitializeSurfaceDataForSurfaceShader(input.uv, surfaceData);
+    SurfaceFunction(input, surfaceData);
+#else
     InitializeStandardLitSurfaceData(input.uv, surfaceData);
+#endif // defined(SURFACE_SHADER)
 
 #ifdef LOD_FADE_CROSSFADE
     LODFadeCrossFade(input.positionCS);

--- a/Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl
+++ b/Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl
@@ -248,6 +248,26 @@ half3 ApplyDetailNormal(float2 detailUv, half3 normalTS, half detailMask)
 #endif
 }
 
+// CUSTOM: SURFACESHADERS: A way to populate the surface data just with default values, which the surface function can then override.
+inline void InitializeSurfaceDataForSurfaceShader(float2 uv, out SurfaceData outSurfaceData)
+{
+    outSurfaceData.albedo = 1;
+    outSurfaceData.alpha = 1;
+
+    outSurfaceData.metallic = 0;
+    outSurfaceData.specular = half3(0.0, 0.0, 0.0);
+
+    outSurfaceData.smoothness = .5;
+    outSurfaceData.normalTS = half3(0, 0, 1);
+    outSurfaceData.occlusion = 1;
+    outSurfaceData.emission = 0;
+    
+    outSurfaceData.clearCoatMask = 0;
+    outSurfaceData.clearCoatSmoothness = 0;
+    
+    outSurfaceData.custom0 = 0;
+}
+
 inline void InitializeStandardLitSurfaceData(float2 uv, out SurfaceData outSurfaceData)
 {
     half4 albedoAlpha = SampleAlbedoAlpha(uv, TEXTURE2D_ARGS(_BaseMap, sampler_BaseMap));


### PR DESCRIPTION
Added some code to let you write 'surface shaders' again like you would in BRP.


For the uninitiated, surface shaders were an approach that let you only declare a "surface function" that returns a struct with the various surface properties, and it would then generate the fragment function for you.

It let you focus on just the properties that define how that shader should be visualized and avoided a lot of duplicate code.

URP does not have this feature any more which is quite a shame. I hope they improve the workflow for writing shaders in code, because using Shader Graph does not suit everyone and should not be the only supported way to make shaders.


This is an _approximation_ of that workflow based on [a repository by Felipe Lira from Unity](https://github.com/phi-lira/UniversalShaderExamples/tree/master/Assets/_ExampleScenes/51_LitPhysicallyBased).

The current setup may not support all Unity features. This feature is opt-in, so use it at your own discretion.